### PR TITLE
Removing priority in fulfill_promise

### DIFF
--- a/src/runtime.hpp
+++ b/src/runtime.hpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <numeric>
 #include <functional>
+#include <limits>
 
 #include "util.hpp"
 
@@ -585,9 +586,9 @@ private:
     {
         assert(comm_rank() == 0);
         assert(from >= 0 && from < comm_size());
-        assert(msg_rcvd.size() == comm_size());
-        assert(msg_sent.size() == comm_size());
-        assert(msg_rcv_snt_uptd.size() == comm_size());
+        assert(msg_rcvd.size() == (size_t)comm_size());
+        assert(msg_sent.size() == (size_t)comm_size());
+        assert(msg_rcv_snt_uptd.size() == (size_t)comm_size());
         assert(n_msg_rcvd >= 0);
         assert(n_msg_sent >= 0);
 
@@ -834,7 +835,7 @@ public:
     // If task cannot be found in the task map, create a new entry.
     // If it exists, reduce by 1 the dependency count.
     // If count == 0, insert the task in the ready queue.
-    void fulfill_promise(K k, double priority = 1.0)
+    void fulfill_promise(K k)
     {
         // Shortcut: if indegree == 1, we can insert the
         // task immediately.
@@ -853,7 +854,7 @@ public:
         Task *t = new Task();
         t->fulfill = []() {};
         t->name = "dep_map_intern_" + to_string(where);
-        t->priority = priority;
+        t->priority = std::numeric_limits<double>::max();
 
         t->run = [this, where, k]() {
             auto &dmk = this->dep_map[where];

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -49,7 +49,7 @@ private:
         size_t total;
         for_size_buffer() : total(0) {}
         template <typename T>
-        void operator()(T &t)
+        void operator()(T&)
         {
             total += sizeof(T);
         }
@@ -143,8 +143,8 @@ class Serializer<>
 {
 public:
     int size() { return 0; };
-    void write_buffer(char *buffer){};
-    std::tuple<> read_buffer(char *buffer) { return {}; };
+    void write_buffer(char *){};
+    std::tuple<> read_buffer(char *) { return {}; };
 };
 
 void print_bytes(const void *ptr, int size);

--- a/tests/mpi/ddot_test.cpp
+++ b/tests/mpi/ddot_test.cpp
@@ -96,7 +96,7 @@ void ddot(int n_threads, int block_size)
         .set_name([&](int k) {
             return "ddot_" + to_string(k) + "_" + to_string(rank);
         })
-        .set_indegree([](int k) {
+        .set_indegree([](int) {
             return 1;
         })
         .set_task([&](int k) {
@@ -115,16 +115,16 @@ void ddot(int n_threads, int block_size)
             dlog.add_event(DepsEvent(dot_tf.name(k), add_tf.name(0)));
         });
 
-    add_tf.set_mapping([&](int k) {
+    add_tf.set_mapping([&](int) {
               return 0;
           })
         .set_name([&](int k) {
             return "add_" + to_string(k) + "_" + to_string(rank);
         })
-        .set_indegree([&](int k) {
+        .set_indegree([&](int) {
             return n_threads;
         })
-        .set_task([&](int k) {
+        .set_task([&](int) {
             partial_sum = z.sum();
         })
         .set_fulfill([&](int k) {

--- a/tests/mpi/tests_completion.cpp
+++ b/tests/mpi/tests_completion.cpp
@@ -41,7 +41,7 @@ TEST(completion, mini)
     tf.set_mapping([&](int k) {
           return (k % n_threads);
       })
-        .set_indegree([&](int k) {
+        .set_indegree([&](int) {
             return 1;
         })
         .set_task([&](int k) {
@@ -75,6 +75,8 @@ int main(int argc, char **argv)
 
     assert(prov == req);
 
+    ::testing::InitGoogleTest(&argc, argv);
+
     if (argc >= 2)
     {
         n_threads = atoi(argv[1]);
@@ -84,8 +86,6 @@ int main(int argc, char **argv)
     {
         verb = atoi(argv[2]);
     }
-
-    ::testing::InitGoogleTest(&argc, argv);
 
     const int return_flag = RUN_ALL_TESTS();
 

--- a/tests/shared/tests_serialize.cpp
+++ b/tests/shared/tests_serialize.cpp
@@ -59,7 +59,7 @@ TEST(serialize,all) {
     test<float>(3.141519);
     test<float>(-3.141519);
     test<int,double,float,char>(1,2.71,-3.14,'A');
-    test<void(*)(int)>([](int i){printf("Test\n");});
+    test<void(*)(int)>([](int){printf("Test\n");});
     test<double,int,float,s1_t,s2_t>(1.23, 2, 4.32, {5, 6}, {3.14, 2.71, {-1,1}, {-2,2}});
 }
 
@@ -76,10 +76,10 @@ TEST(serialize,views) {
     auto tup = s2.read_buffer(buffer.data());
     ASSERT_EQ(get<0>(tup).size(), 5);
     ASSERT_EQ(get<1>(tup).size(), 4);
-    for(int i = 0; i < d1.size(); i++) {
+    for(int i = 0; (size_t)i < d1.size(); i++) {
         ASSERT_EQ( *(get<0>(tup).begin() + i), d1[i] );
     }
-    for(int i = 0; i < d2.size(); i++) {
+    for(int i = 0; (size_t)i < d2.size(); i++) {
         ASSERT_EQ( *(get<1>(tup).begin() + i), d2[i] );
     }
 }


### PR DESCRIPTION
Removing need to specify priorities of fulfill by setting them to numeric_limits<double>::max(), plus silencing warnings for unused variables and comparing int vs size_t