### PR TITLE
Adding TASKTORRENT_MPI_CHECK macro

### DIFF
--- a/src/communications.hpp
+++ b/src/communications.hpp
@@ -27,6 +27,15 @@
 #include "apply_functions.hpp"
 #include "functional_extra.hpp"
 
+#define TASKTORRENT_MPI_CHECK( call ) do { \
+    int err = call; \
+    if (err != MPI_SUCCESS) { \
+        fprintf(stderr, "TaskTorrent: MPI error %d in file %s at line %i\n", \
+              err, __FILE__, __LINE__); \
+        MPI_Finalize(); \
+        exit(1); \
+    }   } while(0)
+
 namespace ttor
 {
 
@@ -370,8 +379,7 @@ void Communicator::blocking_send(unique_ptr<message> m)
     messages_queued++;
 
     Isend_message(m);
-    int err = MPI_Wait(&m->request, MPI_STATUS_IGNORE);
-    assert(err == MPI_SUCCESS);
+    TASKTORRENT_MPI_CHECK(MPI_Wait(&m->request, MPI_STATUS_IGNORE));
 }
 
 } // namespace ttor

--- a/src/communications.hpp
+++ b/src/communications.hpp
@@ -314,7 +314,7 @@ void ActiveMsg<Ps...>::named_send(int dest, string name, Ps &... ps)
 }
 
 template <typename... Ps>
-ActiveMsg<Ps...>::~ActiveMsg(){};
+ActiveMsg<Ps...>::~ActiveMsg(){}
 
 template <typename... Ps>
 ActiveMsg<Ps...> *Communicator::make_active_msg(function<void(Ps &...)> fun)

--- a/src/communications.hpp
+++ b/src/communications.hpp
@@ -30,8 +30,8 @@
 #define TASKTORRENT_MPI_CHECK( call ) do { \
     int err = call; \
     if (err != MPI_SUCCESS) { \
-        fprintf(stderr, "TaskTorrent: MPI error %d in file %s at line %i\n", \
-              err, __FILE__, __LINE__); \
+        fprintf(stderr, "TaskTorrent: MPI error %d in file %s at line %i in function %s\n", \
+              err, __FILE__, __LINE__, __func__); \
         MPI_Finalize(); \
         exit(1); \
     }   } while(0)

--- a/src/functional_extra.hpp
+++ b/src/functional_extra.hpp
@@ -24,6 +24,6 @@ template<typename F>
 typename fun_type<decltype(&F::operator())>::type GetStdFunction(F const &func)
 {
     return func;
-};
+}
 
 #endif

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -40,8 +40,8 @@ namespace ttor {
         end = wctime();
     }
 
-    Logger::Logger(int N) : origin(wctime()), printed_warning(false), i(0), events(N) {};
-    Logger::Logger() : origin(wctime()), printed_warning(false), i(0), events(0) {};
+    Logger::Logger(int N) : origin(wctime()), printed_warning(false), i(0), events(N) {}
+    Logger::Logger() : origin(wctime()), printed_warning(false), i(0), events(0) {}
     void Logger::add_event(std::unique_ptr<Event> e) {
         int id = (i++); // atomic
         if(id < int(events.size())) {
@@ -75,9 +75,9 @@ namespace ttor {
         self_name = s;
         out_deps_name = o;
     }
-    DepsEvent::DepsEvent() {};
-    DepsLogger::DepsLogger(int N) : i(0), printed_warning(false), events(N) {};
-    DepsLogger::DepsLogger() : i(0), printed_warning(false), events(0) {};
+    DepsEvent::DepsEvent() {}
+    DepsLogger::DepsLogger(int N) : i(0), printed_warning(false), events(N) {}
+    DepsLogger::DepsLogger() : i(0), printed_warning(false), events(0) {}
     void DepsLogger::add_event(std::unique_ptr<DepsEvent> e) {
         int id = (i++); // atomic
         if(id < int(events.size())) {


### PR DESCRIPTION
Using that macro instead of assert(..) to preserve checks when `NDEBUG` is defined. The runtime cost is minimal and MPI failures are difficult bugs to solve.