### PR TITLE
Fixes alignment. view<T> are now serialized and deserialized at an aligned address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ script:
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/sparse_cholesky && cp Makefile.conf.travis Makefile.conf && make clean && make snchol && mpirun -n 2 ./snchol neglapl_2_32.mm 10 2 0 5 0 NONE 5
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) OFF
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) UB
-  - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) ADDRESS

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ compiler:
   - g++
 install:
 script:
+  - cd ${HOME}/build/leopoldcambier/tasktorrent/tutorial && make clean && make run
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/dense_cholesky && cp Makefile.conf.travis Makefile.conf && make clean && make cholesky && mpirun -n 2 ./cholesky
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/3d_gemm && cp Makefile.conf.travis Makefile.conf && make clean && make 3d_gemm && mpirun --oversubscribe -n 8 ./3d_gemm
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/sparse_cholesky && cp Makefile.conf.travis Makefile.conf && make clean && make snchol && mpirun -n 2 ./snchol neglapl_2_32.mm 10 2 0 5 0 NONE 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,4 @@ script:
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/sparse_cholesky && cp Makefile.conf.travis Makefile.conf && make clean && make snchol && mpirun -n 2 ./snchol neglapl_2_32.mm 10 2 0 5 0 NONE 5
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) OFF
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) UB
-  - cd ${HOME}/build/leopoldcambier/tasktorrent && ASAN_OPTIONS=detect_leaks=0 EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) ADDRESS
-  - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) THREAD
-  
+  - cd ${HOME}/build/leopoldcambier/tasktorrent && ASAN_OPTIONS=detect_leaks=0 EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) ADDRESS  

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ script:
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) OFF
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) UB
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) ADDRESS
-  - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) THREAD

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ script:
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/3d_gemm && cp Makefile.conf.travis Makefile.conf && make clean && make 3d_gemm && mpirun --oversubscribe -n 8 ./3d_gemm
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/sparse_cholesky && cp Makefile.conf.travis Makefile.conf && make clean && make snchol && mpirun -n 2 ./snchol neglapl_2_32.mm 10 2 0 5 0 NONE 5
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) OFF
+  - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) UB
+  - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) ADDRESS
+  - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) THREAD

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ script:
   - cd ${HOME}/build/leopoldcambier/tasktorrent/miniapp/sparse_cholesky && cp Makefile.conf.travis Makefile.conf && make clean && make snchol && mpirun -n 2 ./snchol neglapl_2_32.mm 10 2 0 5 0 NONE 5
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) OFF
   - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) UB
+  - cd ${HOME}/build/leopoldcambier/tasktorrent && ASAN_OPTIONS=detect_leaks=0 EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) ADDRESS
+  - cd ${HOME}/build/leopoldcambier/tasktorrent && EIGEN3_ROOT=${HOME}/build/leopoldcambier/tasktorrent/eigen ./tests/test_all.sh $(pwd) THREAD
+  

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <cstring>
 #include <cassert>
+#include <memory>
 
 #include "views.hpp"
 

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -15,6 +15,7 @@
 template <std::size_t... Ns, typename... Ts>
 constexpr auto tail_impl(std::index_sequence<Ns...>, std::tuple<Ts...> t)
 {
+    (void)t;
     return std::make_tuple(std::get<Ns + 1u>(t)...);
 }
 

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -82,8 +82,8 @@ private:
         {
             memcpy(p, &t, sizeof(T));
             p += sizeof(T);
+            assert(size >= sizeof(T));
             size -= sizeof(T);
-            assert(size >= 0);
         }
         template <typename T>
         void operator()(view<T> &t)
@@ -92,8 +92,8 @@ private:
             size_t length = t.size();
             memcpy(p, &length, sizeof(size_t));
             p += sizeof(size_t);
+            assert(size >= sizeof(size_t));
             size -= sizeof(size_t);
-            assert(size >= 0);
             if(length > 0) {
                 assert(size > 0);
                 // Align
@@ -101,13 +101,12 @@ private:
                 void* error = std::align(alignof(T), sizeof(T), pv, size);
                 p = (char*)pv;
                 assert(error != nullptr);
-                assert(size >= 0);
                 // Serialize the data at the now aligned address
                 size_t size_view = length * sizeof(T);
                 memcpy(p, t.data(), size_view);
                 p += size_view;
+                assert(size >= size_view);
                 size -= size_view;
-                assert(size >= 0);
             }
         }
         // TODO: Specialize for other types
@@ -127,8 +126,8 @@ private:
         {
             memcpy(&t, p, sizeof(T));
             p += sizeof(T);
+            assert(size >= sizeof(T));
             size -= sizeof(T);
-            assert(size >= 0);
         }
         template <typename T>
         void operator()(view<T> &t)
@@ -137,8 +136,8 @@ private:
             size_t length;
             memcpy(&length, p, sizeof(size_t));
             p += sizeof(size_t);
+            assert(size >= sizeof(T));
             size -= sizeof(T);
-            assert(size >= 0);
             if(length > 0) {
                 assert(size > 0);
                 // Align
@@ -146,14 +145,13 @@ private:
                 void* error = std::align(alignof(T), sizeof(T), pv, size);
                 p = (char*)pv;
                 assert(error != nullptr);
-                assert(size >= 0);
                 // Deserialize data - avoid unnecessary copy and fetch the (aligned) pointer
                 size_t size_view = length * sizeof(T);
                 T *start = reinterpret_cast<T *>(p);
                 t = view<T>(start, length);
                 p += size_view;
+                assert(size >= size_view);
                 size -= size_view;
-                assert(size >= 0);
             } else {
                 t = view<T>(nullptr, 0);
             }

--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <utility>
 #include <cstring>
+#include <cassert>
 
 #include "views.hpp"
 

--- a/tests/shared/tests_serialize.cpp
+++ b/tests/shared/tests_serialize.cpp
@@ -75,8 +75,8 @@ TEST(serialize,views) {
     vector<char> buffer(size);
     s1.write_buffer(buffer.data(), size, v1, v2);
     auto tup = s2.read_buffer(buffer.data(), size);
-    ASSERT_EQ(get<0>(tup).size(), 5);
-    ASSERT_EQ(get<1>(tup).size(), 4);
+    ASSERT_EQ((int)get<0>(tup).size(), 5);
+    ASSERT_EQ((int)get<1>(tup).size(), 4);
     for(int i = 0; (size_t)i < d1.size(); i++) {
         ASSERT_EQ( *(get<0>(tup).begin() + i), d1[i] );
     }
@@ -145,9 +145,9 @@ TEST(serialize,empty_views) {
     vector<char> buffer(size);
     s.write_buffer(buffer.data(), buffer.size(), z, a_v, b_v, c_v);
     auto tup = s.read_buffer(buffer.data(), buffer.size());
-    ASSERT_EQ(get<1>(tup).size(), 0);
-    ASSERT_EQ(get<2>(tup).size(), 1);
-    ASSERT_EQ(get<3>(tup).size(), 0);
+    ASSERT_EQ((int)get<1>(tup).size(), 0);
+    ASSERT_EQ((int)get<2>(tup).size(), 1);
+    ASSERT_EQ((int)get<3>(tup).size(), 0);
 }
 
 /**

--- a/tests/shared/tests_serialize.cpp
+++ b/tests/shared/tests_serialize.cpp
@@ -19,9 +19,10 @@ template<typename... T>
 void test(T... t) {
     Serializer<T...> s1;
     Serializer<T...> s2;
-    vector<char> buffer(s1.size(t...));
-    s1.write_buffer(buffer.data(), t...);
-    auto tup = s2.read_buffer(buffer.data());
+    size_t s = s1.size(t...);
+    vector<char> buffer(s);
+    s1.write_buffer(buffer.data(), s, t...);
+    auto tup = s2.read_buffer(buffer.data(), s);
     ASSERT_EQ(tup, make_tuple(t...));
 }
 
@@ -70,9 +71,10 @@ TEST(serialize,views) {
     auto v2 = view<double>(d2.data(), d2.size());
     Serializer<view<int>, view<double>> s1;
     Serializer<view<int>, view<double>> s2;
-    vector<char> buffer(s1.size(v1, v2));
-    s1.write_buffer(buffer.data(), v1, v2);
-    auto tup = s2.read_buffer(buffer.data());
+    size_t size = s1.size(v1, v2);
+    vector<char> buffer(size);
+    s1.write_buffer(buffer.data(), size, v1, v2);
+    auto tup = s2.read_buffer(buffer.data(), size);
     ASSERT_EQ(get<0>(tup).size(), 5);
     ASSERT_EQ(get<1>(tup).size(), 4);
     for(int i = 0; (size_t)i < d1.size(); i++) {
@@ -80,6 +82,53 @@ TEST(serialize,views) {
     }
     for(int i = 0; (size_t)i < d2.size(); i++) {
         ASSERT_EQ( *(get<1>(tup).begin() + i), d2[i] );
+    }
+}
+
+TEST(serialize,alignement) {
+    short a = 42;
+    int b = 271;
+    double c = 3.14;
+    long long d = 4478687;
+    vector<int> e = {1, 2, 3};
+    vector<double> f = {10.10, 11.11, 12.12};
+    Serializer<short,int,double,long long,view<int>,view<double>> s;
+    auto e_v = view<int>(e.data(), e.size());
+    auto f_v = view<double>(f.data(), f.size());
+    size_t size = s.size(a,b,c,d,e_v,f_v);
+    vector<char> buffer(size);
+    s.write_buffer(buffer.data(), buffer.size(), a, b, c, d, e_v, f_v);
+    auto tup = s.read_buffer(buffer.data(), buffer.size());
+    ASSERT_EQ(get<0>(tup), a);
+    ASSERT_EQ(get<1>(tup), b);
+    ASSERT_EQ(get<2>(tup), c);
+    ASSERT_EQ(get<3>(tup), d);
+    for(int i = 0; i < 3; i++) {
+        ASSERT_EQ(e[i], *(get<4>(tup).data() + i));
+        ASSERT_EQ(f[i], *(get<5>(tup).data() + i));
+    }
+}
+
+TEST(serialize,alignement2) {
+    vector<char> a = {'l', 'o', 'l'};
+    vector<int> b = {1, 2, 3, 4};
+    vector<double> c = {10.10, 11.11};
+    Serializer<view<char>,view<int>,view<double>> s;
+    auto a_v = view<char>(a.data(), a.size());
+    auto b_v = view<int>(b.data(), b.size());
+    auto c_v = view<double>(c.data(), c.size());
+    size_t size = s.size(a_v, b_v, c_v);
+    vector<char> buffer(size);
+    s.write_buffer(buffer.data(), buffer.size(), a_v, b_v, c_v);
+    auto tup = s.read_buffer(buffer.data(), buffer.size());
+    for(int i = 0; i < 3; i++) {
+        ASSERT_EQ(a[i], *(get<0>(tup).data() + i));
+    }
+    for(int i = 0; i < 4; i++) {
+        ASSERT_EQ(b[i], *(get<1>(tup).data() + i));
+    }
+    for(int i = 0; i < 2; i++) {
+        ASSERT_EQ(c[i], *(get<2>(tup).data() + i));
     }
 }
 
@@ -96,10 +145,11 @@ TEST(serialize,large) {
     ASSERT_TRUE(data != nullptr);
     auto vdata = view<char>(data, size);
     Serializer<view<char>> s;
-    char* output = (char*)malloc( s.size(vdata) * sizeof(char) );
+    size_t buffer_size = s.size(vdata);
+    char* output = (char*)malloc( buffer_size * sizeof(char) );
     ASSERT_TRUE(output != nullptr);
-    s.write_buffer(output, vdata);
-    auto tup = s.read_buffer(output);
+    s.write_buffer(output, buffer_size, vdata);
+    auto tup = s.read_buffer(output, buffer_size);
     view<char>& voutput = get<0>(tup);
     ASSERT_EQ(voutput.size(), vdata.size());
     for(size_t i = 0; i < vdata.size(); i += static_cast<size_t>(1e5)) { // Too slow otherwise

--- a/tests/shared/tests_serialize.cpp
+++ b/tests/shared/tests_serialize.cpp
@@ -132,6 +132,24 @@ TEST(serialize,alignement2) {
     }
 }
 
+TEST(serialize,empty_views) {
+    int z = 0;
+    vector<char> a = {};
+    vector<int> b = {1};
+    vector<double> c = {};
+    Serializer<int,view<char>,view<int>,view<double>> s;
+    auto a_v = view<char>(a.data(), a.size());
+    auto b_v = view<int>(b.data(), b.size());
+    auto c_v = view<double>(c.data(), c.size());
+    size_t size = s.size(z,a_v, b_v, c_v);
+    vector<char> buffer(size);
+    s.write_buffer(buffer.data(), buffer.size(), z, a_v, b_v, c_v);
+    auto tup = s.read_buffer(buffer.data(), buffer.size());
+    ASSERT_EQ(get<1>(tup).size(), 0);
+    ASSERT_EQ(get<2>(tup).size(), 1);
+    ASSERT_EQ(get<3>(tup).size(), 0);
+}
+
 /**
  * Check that we can serialize message of more than 2^31 (limit of int) bytes
  * We should be able to serialize up to std::numeric_limits<size_t>::max() bytes

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -18,18 +18,6 @@ else
 fi
 printf "TTOR's source set to ${dir}"
 
-# Tutorial test
-printf "\nTesting tutorial\n"
-
-cd $dir/tutorial
-make clean
-make run
-
-if [ $? != "0" ]
-then
-    exit 1
-fi
-
 # Sanitizer as an option
 SAN=$2
 if [ -z "$SAN" ]


### PR DESCRIPTION
This makes sure that the Serializer::write_buffer function copies view's data at an align address.
This assumes that the provided pointer is itself aligned.